### PR TITLE
Add: younseop_programmers_reportResult

### DIFF
--- a/programmers/report-result/모범답안.md
+++ b/programmers/report-result/모범답안.md
@@ -1,0 +1,17 @@
+```javascript
+function solution(id_list, report, k) {
+    let reports = [...new Set(report)].map(a=>{return a.split(' ')});
+    let counts = new Map();
+    for (const bad of reports){
+        counts.set(bad[1],counts.get(bad[1])+1||1)
+    }
+    let good = new Map();
+    for(const report of reports){
+        if(counts.get(report[1])>=k){
+            good.set(report[0],good.get(report[0])+1||1)
+        }
+    }
+    let answer = id_list.map(a=>good.get(a)||0)
+    return answer;
+}
+```

--- a/programmers/report-result/문제.md
+++ b/programmers/report-result/문제.md
@@ -1,0 +1,7 @@
+## 문제 출처
+
+2022 카카오 블라인드 채용
+
+## 문제 주소
+
+https://school.programmers.co.kr/learn/courses/30/lessons/92334


### PR DESCRIPTION
## 2022 카카오 블라인드 채용 문제 [신고 결과 받기]

### 풀이

#### 접근 방식
각 이용자가 신고한 이용자의 ID 정보가 담긴 문자열 배열(이하 `report`)의 문자열 배열을 쪼갠 뒤 `split(' ')`으로 신고한 ID를 확인 후 각 ID마다 신고 횟수 `k`에 누적하는 방식으로 해결

#### 문제 해결: 실패
배열을 쪼갠 후 접근하려니 순서가 엉망이 되었고, 오히려 내가 더 헷갈리게 됨
